### PR TITLE
Fix postinstall command for Prisma

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "db:push": "prisma db push --schema src/db/schema.prisma",
     "db:studio": "prisma studio --schema src/db/schema.prisma",
     "email:dev": "maildev -outgoing-host smtp.nextlaunch.com -outgoing-secure --outgoing-user 'myuser' --outgoing-pass 'mypass'",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate  --schema src/db/schema.prisma"
   },
   "dependencies": {
     "@prisma/client": "5.14.0",


### PR DESCRIPTION
This pull request fixes the postinstall command for Prisma by adding the `--schema src/db/schema.prisma` flag. Previously, the command was missing this flag, which caused issues with generating the Prisma client. This fix ensures that the Prisma client is generated correctly during the postinstall process.