### PR TITLE
Add server-only to services and lang action in landing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-dom": "^18.3.1",
     "react-email": "2.1.4",
     "rtl-detect": "^1.1.2",
+    "server-only": "^0.0.1",
     "ts-node": "^10.9.2",
     "uuid": "^10.0.0",
     "zod": "^3.23.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       rtl-detect:
         specifier: ^1.1.2
         version: 1.1.2
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.5))(@types/node@20.14.2)(typescript@5.4.5)
@@ -3876,6 +3879,9 @@ packages:
   serve-static@1.15.0:
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
     engines: {node: '>= 0.8.0'}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -8446,6 +8452,8 @@ snapshots:
       send: 0.18.0
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   set-blocking@2.0.0: {}
 

--- a/src/actions/lang/change.ts
+++ b/src/actions/lang/change.ts
@@ -1,0 +1,16 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { z } from "zod";
+import locales from "@/lang/locales";
+import { Locale } from "@/types/lang";
+
+const localeSchema = z.enum(locales);
+
+async function changeLang(lang: Locale): Promise<void> {
+  const locale = localeSchema.safeParse(lang);
+  if (!locale.success) return;
+  cookies().set({ name: "locale", value: locale.data, secure: true });
+}
+
+export default changeLang;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import { Metadata } from "next";
 import { useTranslations } from "next-intl";
+import Languages from "@/components/languages";
 
 export const metadata: Metadata = {
   title: "Welcome to Next Launch ",
@@ -17,7 +18,7 @@ function Page(): ReactNode {
         <h1 className="mt-8 text-center text-3xl font-bold">{t("title")}</h1>
         <p className="mt-4 text-center text-lg">{t("description")}</p>
         <p className="mt-4 text-center text-sm text-gray-500">{t("headless")}</p>
-        <small className="mb-32 mt-4 block w-full text-center text-sm text-gray-500">
+        <small className="mt-4 block w-full text-center text-sm text-gray-500">
           {t("contribute.made")}{" "}
           <a href="https://twitter.com/pierregueroult1" className="underline" target="_blank" rel="noreferrer">
             {t("contribute.by")}
@@ -34,6 +35,7 @@ function Page(): ReactNode {
           </a>
           .
         </small>
+        <Languages />
       </section>
       <section className="mt-16 flex h-screen w-full flex-col items-center justify-center">
         <div>

--- a/src/components/languages.tsx
+++ b/src/components/languages.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React, { FormEvent } from "react";
+import changeLang from "@/actions/lang/change";
+import locales from "@/lang/locales";
+import { useLocale } from "next-intl";
+import { Locale } from "@/types/lang";
+
+export default function Languages() {
+  const currentLocale = useLocale();
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const lang: string = ((e.target as HTMLFormElement).elements.namedItem("locale") as HTMLInputElement).value;
+    if (locales.includes(lang as Locale)) await changeLang(lang as Locale);
+  };
+
+  return (
+    <ul className="mb-32 mt-4 flex flex-row items-center justify-center gap-4">
+      {locales.map((locale) => (
+        <li key={locale}>
+          <form onSubmit={(e) => handleSubmit(e)}>
+            <button
+              className={`uppercase ${currentLocale === locale ? "text-black underline" : "text-gray-500"}`}
+              type="submit"
+              name="locale"
+              value={locale}
+            >
+              {locale}
+            </button>
+          </form>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -1,8 +1,9 @@
-/* eslint-disable import/prefer-default-export */
+import "server-only";
 
 import prisma from "@/db";
 import { Account } from "@/db/types";
 
+/* eslint-disable import/prefer-default-export */
 export const getAccountByUserId = async (userId: string): Promise<Account | null> =>
   prisma.account.findFirst({
     where: { userId },

--- a/src/services/two-factor-confirmation.ts
+++ b/src/services/two-factor-confirmation.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import prisma from "@/db";
 import { TwoFactorConfirmation } from "@/db/types";
 

--- a/src/services/two-factor-token.ts
+++ b/src/services/two-factor-token.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import prisma from "@/db";
 import { TwoFactorToken } from "@/db/types";
 

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import prisma from "@/db";
 import { User } from "@/db/types";
 

--- a/src/services/verification-token.ts
+++ b/src/services/verification-token.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import prisma from "@/db";
 import { VerificationToken } from "@/db/types";
 

--- a/src/types/lang.ts
+++ b/src/types/lang.ts
@@ -1,0 +1,3 @@
+import locales from "@/lang/locales";
+
+export type Locale = (typeof locales)[number];


### PR DESCRIPTION
This pull request includes the addition of the "server-only" package to the project's dependencies. It also adds a new action called "changeLang" in the landing page that allows users to change the language of the application. The "changeLang" action sets a cookie with the selected language and updates the UI accordingly.